### PR TITLE
Fix lib name in depencency declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ See [API.md](./API.md)
 ### Deps
 
 ```clojure
-io.github.bsless/jsonista.streaming {:mvn/version "0.0.2"}
+io.github.bsless/jsonista.streams {:mvn/version "0.0.2"}
 ```
 
 ### Leiningen
 
 ```clojure
-[io.github.bsless/jsonista.streaming "0.0.2"]
+[io.github.bsless/jsonista.streams "0.0.2"]
 ```
 
 ## Usage


### PR DESCRIPTION
Hello,
I just tried to add your lib as a dependency and figured out that the name exposed on the README is not the same than on clojars.org.